### PR TITLE
Fix form status visibility

### DIFF
--- a/css/components/forms.css
+++ b/css/components/forms.css
@@ -216,12 +216,14 @@
   background: rgba(0,226,195,0.1);
   border: 1px solid rgba(0,226,195,0.3);
   color: var(--primary);
+  display: block;
 }
 
 .form-status.error {
   background: rgba(255,73,73,0.1);
   border: 1px solid rgba(255,73,73,0.3);
   color: #ff4949;
+  display: block;
 }
 
 .form-header {


### PR DESCRIPTION
## Summary
- show success and error messages for form status by default

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68436fd19fb4832d8edbf8b952c037c3