### PR TITLE
Remove lazy loading from shapes

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,9 +72,9 @@
   </div>
 
   <!-- Decoration shapes -->
-  <div class="shape shape-1" loading="lazy"></div>
-  <div class="shape shape-2" loading="lazy"></div>
-  <div class="shape shape-3" loading="lazy"></div>
+  <div class="shape shape-1"></div>
+  <div class="shape shape-2"></div>
+  <div class="shape shape-3"></div>
 
   <!-- Main Content -->
   <main id="main">


### PR DESCRIPTION
## Summary
- remove `loading="lazy"` from decorative shape divs in `index.html`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68436fd53594832d9b1de38144dee243