### PR TITLE
Fix mobile menu overlay z-index

### DIFF
--- a/css/components/navigation.css
+++ b/css/components/navigation.css
@@ -4,7 +4,7 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 100;
+  z-index: 200; /* Ensure menu button sits above the mobile overlay */
   padding: 15px 0;
   background: rgba(10, 14, 23, 0.75);
   backdrop-filter: blur(15px);


### PR DESCRIPTION
## Summary
- ensure the mobile menu button remains clickable by bumping `.nav`'s z-index

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843aad2be3c832d914ad3a04316fe2c